### PR TITLE
Update board.c

### DIFF
--- a/board.c
+++ b/board.c
@@ -57,5 +57,7 @@ void print_board()
 
 void modify_board(char jeton, int column, int row)
 {
+    column--;
+    row--;
     board_value[column][row] = jeton;
 }


### PR DESCRIPTION
Small fix : Because both arrays start at 0, the given number for both columns and rows must be reduced by 1. Otherwise, if a user type 2 for 'column' and 2 for 'row', the programm will display the tile in the 3*3 box.